### PR TITLE
improved tagcloud shortcode readability

### DIFF
--- a/layouts/shortcodes/tagcloud.html
+++ b/layouts/shortcodes/tagcloud.html
@@ -1,3 +1,12 @@
-{{ if isset .Site.Taxonomies "tags" }}{{ if not (eq (len .Site.Taxonomies.tags) 0) }}   <ul id="tagcloud">
-    {{ range $name, $items := .Site.Taxonomies.tags }}{{ $url := printf "%s/%s" "tags" ($name | urlize | lower)}}<li><a href="{{ $url | absURL }}" id="tag_{{ $name }}">{{ $name | title }}</a></li>
-    {{ end }}</ul>{{ end }}{{ end }}
+{{ if isset .Site.Taxonomies "tags" }}
+    {{ if not (eq (len .Site.Taxonomies.tags) 0) }}
+        <ul id="tagcloud">
+        {{ range $name, $items := .Site.Taxonomies.tags }}
+            {{ $url := printf "%s/%s" "tags" ($name | urlize | lower)}}
+            <li>
+                <a href="{{ $url | absURL }}" id="tag_{{ $name }}">{{ $name | title }}</a>
+            </li>
+        {{ end }}
+        </ul>
+    {{ end }}
+{{ end }}


### PR DESCRIPTION
The tagcloud shortcode is hard to modify. I broke it down for easier readability.

From this:
```
{{ if isset .Site.Taxonomies "tags" }}{{ if not (eq (len .Site.Taxonomies.tags) 0) }}   <ul id="tagcloud">
    {{ range $name, $items := .Site.Taxonomies.tags }}{{ $url := printf "%s/%s" "tags" ($name | urlize | lower)}}<li><a href="{{ $url | absURL }}" id="tag_{{ $name }}">{{ $name | title }}</a></li>
    {{ end }}</ul>{{ end }}{{ end }}
```

To this:
```
{{ if isset .Site.Taxonomies "tags" }}
    {{ if not (eq (len .Site.Taxonomies.tags) 0) }}
        <ul id="tagcloud">
        {{ range $name, $items := .Site.Taxonomies.tags }}
            {{ $url := printf "%s/%s" "tags" ($name | urlize | lower)}}
            <li>
                <a href="{{ $url | absURL }}" id="tag_{{ $name }}">{{ $name | title }}</a>
            </li>
        {{ end }}
        </ul>
    {{ end }}
{{ end }}
```