### PR TITLE
Add support for custom stylesheet.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ hugo new site new-site
 cd new-site
 git clone https://github.com/lukesmithxyz/lugo themes/lugo
 echo "theme = 'lugo'" >> config.toml
-cp themes/lugo/static/style.css static/
+touch static/custom.css  # put your style changes into that file
 ```
 
 ## stuff

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -5,6 +5,8 @@
 	<link rel="canonical" href="{{ .Site.BaseURL }}">
 	<link rel='alternate' type='application/rss+xml' title="{{ .Site.Title }} RSS" href='/index.xml'>
 	<link rel='stylesheet' type='text/css' href='/style.css'>
+	{{ if os.FileExists "static/custom.css" }}<link rel="stylesheet" type="text/css" href="/custom.css">
+	{{ end -}}
 	{{ with .Site.Params.favicon }}<link rel="icon" href="{{ . }}">
 	{{ end -}}
 	<meta name="description" content="{{ with .Params.description }}{{ . }}{{ else }}{{ .Summary }}{{ end }}">


### PR DESCRIPTION
# What?

Lets the user put their own styles into a `static/custom.css` file, that will be loaded into the header.

# Why?
- This will keep the themes design and the user will only overwrite, what they want to change.
- In the spirit of cascading stylesheets, lets the user build upon the existing style.
- Keeps the ability to receive theme updates for those who like to get them.

# Should you care?

Your decision. I will use this patch anyway.

----

(Thanks for the great hugo walkthrough, btw!) 