### PR TITLE
Add lazy-loading to images

### DIFF
--- a/layouts/shortcodes/img.html
+++ b/layouts/shortcodes/img.html
@@ -10,6 +10,7 @@
 	<img src="{{ .Get "src" }}"
 	     {{- with .Get "mouse" }} title="{{.}}"{{ end -}}
 	     {{- with .Get "alt" }} alt="{{.}}"{{ end -}}
+	     loading="lazy"
 	>
 	{{- if .Get "link"}}</a>{{ end -}}
 	{{- with .Get "caption" -}}


### PR DESCRIPTION
Some can be way down in a blog. This should speed up page loading (and minimize bandwidth for those scrolling down an entire post).