### PR TITLE
Replace 'Site.Author' with 'Site.Params.Author'

### DIFF
--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -4,9 +4,9 @@
 	<link>{{ .Permalink }}</link>
 	<description>Recent content {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
 	<generator>Hugo -- gohugo.io</generator>{{ with .Site.LanguageCode }}
-	<language>{{.}}</language>{{end}}{{ with .Site.Author.email }}
-	<managingEditor>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Author.email }}
-	<webMaster>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
+	<language>{{.}}</language>{{end}}{{ with .Site.Params.Author.email }}
+	<managingEditor>{{.}}{{ with $.Site.Params.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Params.Author.email }}
+	<webMaster>{{.}}{{ with $.Site.Params.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
 	<copyright>{{.}}</copyright>{{end}}{{ if not .Date.IsZero }}
 	<lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
     {{ with .OutputFormats.Get "RSS" }}
@@ -17,7 +17,7 @@
 		<title>{{ .Title }}</title>
 		<link>{{ .Permalink }}</link>
 		<pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
-		{{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
+		{{ with .Site.Params.Author.email }}<author>{{.}}{{ with $.Site.Params.Author.name }} ({{.}}){{end}}</author>{{end}}
 		<guid>{{ .Permalink }}</guid>
 		<description>{{- .Content | html -}}</description>
 	</item>


### PR DESCRIPTION
Site.Author was deprecated in gohugoio/hugo/pull/11569.

Rendering with it fails with this error:

```
execute of template failed: template: rss.xml:7:47: executing "rss.xml" at <.Site.Author.email>: can't evaluate field Author in type page.Site
```

Replacing it with Site.Params.Author fixes it.