### PR TITLE
Use .Site.Language.Locale

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,6 @@
 title = "Website Name"
 baseURL = 'https://example.org'
-languageCode = 'en-us'
+locale = 'en-us'
 
 [params]
   # "relatedtext" is the text that appears above the tag list at the bottom of pages.

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -3,7 +3,7 @@
 	<title>{{ .Site.Title }}</title>
 	<link>{{ .Permalink }}</link>
 	<description>Recent content {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
-	<generator>Hugo -- gohugo.io</generator>{{ with .Site.LanguageCode }}
+	<generator>Hugo -- gohugo.io</generator>{{ with .Site.Language.Locale }}
 	<language>{{.}}</language>{{end}}{{ with .Site.Params.Author.email }}
 	<managingEditor>{{.}}{{ with $.Site.Params.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Params.Author.email }}
 	<webMaster>{{.}}{{ with $.Site.Params.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}


### PR DESCRIPTION
languageCode was deprecated in Hugo v0.158.0:
https://github.com/gohugoio/hugo/releases/tag/v0.158.0